### PR TITLE
feat: ignore and enhance items in deposit data

### DIFF
--- a/src/app/components/Auctions/components/AuctionTable.tsx
+++ b/src/app/components/Auctions/components/AuctionTable.tsx
@@ -1,8 +1,32 @@
 import { Auction } from "@/types";
+import { formatUnits } from "viem";
+import { Address, useToken } from "wagmi";
+import { useChainDetails } from "../hooks/useChainDetails";
 
 export function AuctionTable(props: Auction) {
   const isComplete = props.status === "complete";
   const titleColor = isComplete ? "text-green-600" : "text-gray-500";
+  const {
+    tokenAddress,
+    amount,
+    destinationChainId,
+    sourceChainId,
+    relayerFeePct,
+    message: _message,
+    maxCount: _maxCount,
+    txValue: _txValue,
+    ...depositData
+  } = props.deposit;
+  const { data: tokenData } = useToken({ address: tokenAddress as Address });
+  const enhancedData = {
+    tokenAddress: `${tokenAddress}${tokenData ? ` (${tokenData.name})` : ""}`,
+    amount: tokenData
+      ? `${formatUnits(BigInt(amount), tokenData.decimals)} ${tokenData.symbol}`
+      : amount,
+    sourceChain: useChainDetails(sourceChainId)?.name,
+    destinationChain: useChainDetails(destinationChainId)?.name,
+    relayerFee: `${relayerFeePct}%`,
+  };
   return (
     <div>
       <h2 className="pl-5 text-2xl font-medium">
@@ -15,7 +39,25 @@ export function AuctionTable(props: Auction) {
           Deposit
         </caption>
         <tbody>
-          {Object.entries(props.deposit).map(([key, value], index) => (
+          <>
+            {Object.entries(enhancedData).map(([key, value], index) => (
+              <tr
+                key={key}
+                className={index % 2 === 0 ? "bg-white" : "bg-gray-50"}
+              >
+                <th
+                  scope="row"
+                  className="whitespace-nowrap py-1 font-medium text-gray-700"
+                >
+                  <strong className="px-6 py-4 font-semibold">
+                    {camelToTitleCase(key)}
+                  </strong>
+                </th>
+                <td className="px-2 py-4">{value}</td>
+              </tr>
+            ))}
+          </>
+          {Object.entries(depositData).map(([key, value], index) => (
             <tr
               key={index}
               className={index % 2 === 0 ? "bg-white" : "bg-gray-50"}
@@ -24,11 +66,9 @@ export function AuctionTable(props: Auction) {
                 scope="row"
                 className="whitespace-nowrap py-1 font-medium text-gray-700"
               >
-                <td className="px-6 py-4">
-                  <strong className="font-semibold">
-                    {camelToTitleCase(key)}
-                  </strong>
-                </td>
+                <strong className="px-6 py-4 font-semibold">
+                  {camelToTitleCase(key)}
+                </strong>
               </th>
               <td className="px-2 py-4">{value}</td>
             </tr>

--- a/src/app/components/Auctions/hooks/useAuctions.ts
+++ b/src/app/components/Auctions/hooks/useAuctions.ts
@@ -2,7 +2,6 @@ import { Auction, Deposit } from "@/types";
 import { useEffect } from "react";
 import { useImmer } from "use-immer";
 import { useAuctionsSubscription } from "./useAuctionsSubscription";
-
 export function useAuctions() {
   const [auctions, setAuctions] = useImmer<Record<string, Auction>>({});
   const { event } = useAuctionsSubscription();

--- a/src/app/components/Auctions/hooks/useChainDetails.ts
+++ b/src/app/components/Auctions/hooks/useChainDetails.ts
@@ -1,0 +1,14 @@
+import * as chains from "viem/chains";
+
+export function useChainDetails(chainIdString: string | undefined) {
+  const chainId = Number(chainIdString);
+  if (!chainId || isNaN(chainId)) return;
+  const chainsList = Object.values(chains);
+  const chainIds = chainsList.map((chain) => chain.id);
+  if (!chainIds.includes(chainId)) {
+    throw new Error(`Unknown chainId ${chainId}`);
+  }
+  const chain = chainsList.find((chain) => chain.id === chainId);
+
+  return chain;
+}

--- a/src/app/components/pages/Auction.tsx
+++ b/src/app/components/pages/Auction.tsx
@@ -52,7 +52,9 @@ export function Auction() {
           </h1>
         ) : (
           auctionsList.map((auction) => (
-            <AuctionTable key={auction.auctionId} {...auction} />
+            <section key={auction.auctionId} className="mb-6">
+              <AuctionTable {...auction} />
+            </section>
           ))
         )}
       </>

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ export type DepositData = {
   tokenAddress: string;
   amount: string;
   destinationChainId: string;
+  sourceChainId: string;
   relayerFeePct: string;
   quoteTimestamp: string;
   message: string;


### PR DESCRIPTION
add padding between multiple auctions

remove unnecessary data items in deposit data from table

map chain id to chain name for source and destination chains

attempt to enhance balance and token address with token info if possible, else fallback. for some reason the address used in the test data returns just '0x' when querying its decimals, but this should work for other less weird tokens
